### PR TITLE
changing loginMessage type to BROADCAST (#41)

### DIFF
--- a/src/main/java/com/flux/FluxConfig.java
+++ b/src/main/java/com/flux/FluxConfig.java
@@ -46,7 +46,7 @@ public interface FluxConfig extends Config {
     }
 
     @ConfigItem(position = 8, keyName = "loginColor", name = "Login Message Color", description = "The color of the Login Message.", section = overlaySection)
-    default Color loginColor() {return new Color(180, 0, 0); } //Custom dark red.
+    default Color loginColor() {return new Color(255, 255, 0); } //Custom dark red.
 
 // ========== OVERLAY SECTION - HIDDEN ==========
 

--- a/src/main/java/com/flux/FluxPlugin.java
+++ b/src/main/java/com/flux/FluxPlugin.java
@@ -14,8 +14,11 @@ import javax.inject.Inject;
 
 import lombok.extern.slf4j.Slf4j;
 
+import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.GameState;
+import net.runelite.api.MessageNode;
+import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.config.ConfigManager;
@@ -48,6 +51,7 @@ public class FluxPlugin extends Plugin {
     @Inject private FluxOverlay overlay;
     @Inject private ClientToolbar clientToolbar;
     @Inject private OkHttpClient okHttpClient;
+    @Inject private net.runelite.client.callback.ClientThread clientThread;
 
     private FluxPanel panel;
     private NavigationButton uiNavigationButton;
@@ -482,6 +486,21 @@ public class FluxPlugin extends Plugin {
 				panel.getHuntCard().refreshButtonLinks();
 			}
 		}
+    }
+
+    // updates the broadcast message font color from yellow to black for easier reading
+    @Subscribe
+    public void onChatMessage(ChatMessage event) {
+        String loginMessage = loginMessageSender.getLoginMessage();
+        if (loginMessage != null
+                && event.getType() == ChatMessageType.BROADCAST
+                && event.getMessage().contains(loginMessage)) {
+            final MessageNode node = event.getMessageNode();
+            clientThread.invokeLater(() -> {
+                node.setRuneLiteFormatMessage("[Flux] " + loginMessage);
+                chatMessageManager.update(node);
+            });
+        }
     }
 
     @Provides

--- a/src/main/java/com/flux/services/LoginMessageSender.java
+++ b/src/main/java/com/flux/services/LoginMessageSender.java
@@ -38,8 +38,8 @@ public class LoginMessageSender {
 
         chatMessageManager.queue(
                 QueuedMessage.builder()
-                        .type(ChatMessageType.GAMEMESSAGE)
-                        .runeLiteFormattedMessage("<col=" + hex + ">" + loginMessage + "</col>")
+                        .type(ChatMessageType.BROADCAST)
+                        .runeLiteFormattedMessage("<col=" + hex + ">[Flux] " + loginMessage + "</col>")
                         .build()
         );
 
@@ -52,5 +52,9 @@ public class LoginMessageSender {
 
     public boolean hasSentMessage() {
         return hasSentMessage;
+    }
+
+    public String getLoginMessage() {
+        return configManager.getConfiguration(CONFIG_GROUP, CONFIG_KEY);
     }
 }


### PR DESCRIPTION
* changing loginMessage type to BROADCAST
* adding in [flux] prefix to login messages so users know which plugin its from