### PR TITLE
Use `log.debug()` for developer/diagnostic logging.

### DIFF
--- a/src/main/java/com/flux/services/GoogleSheetParser.java
+++ b/src/main/java/com/flux/services/GoogleSheetParser.java
@@ -148,7 +148,7 @@ public class GoogleSheetParser {
 				log.warn("[BOTM] No values returned for range 'BOTM'");
 			}
 
-			log.info("[BOTM] Raw rows count: {}, leaderboard size: {}", values.size(), leaderboard.size());
+			log.debug("[BOTM] Raw rows count: {}, leaderboard size: {}", values.size(), leaderboard.size());
 
 		} catch (IOException e) {
 			log.error("Error fetching Google Sheets data", e);
@@ -223,7 +223,7 @@ public class GoogleSheetParser {
 
         try {
             JsonArray jsonArray = getValues("Config");
-            log.info("[Config] Raw rows count: {}", jsonArray.size());
+            log.debug("[Config] Raw rows count: {}", jsonArray.size());
 
             for (int i = 0; i < jsonArray.size(); i++) {
                 JsonArray row = jsonArray.get(i).getAsJsonArray();

--- a/src/main/java/com/flux/services/wom/WiseOldManApiClient.java
+++ b/src/main/java/com/flux/services/wom/WiseOldManApiClient.java
@@ -49,7 +49,7 @@ public class WiseOldManApiClient {
             if (response.isSuccessful() && response.body() != null) {
                 return response.body().string();
             }
-            log.info("Wise old man request failed response: {}", response);
+            log.warn("Wise old man request failed response: {}", response);
             return EMPTY_STRING;
         } catch (IOException e) {
             log.error("Request failed: {}", e.getMessage());


### PR DESCRIPTION
Do not use `log.info` for per-frame or per-event logging - RuneLite runs at INFO level in production, so high-frequency info logs will pollute user logs.