### PR TITLE
Prepend clan icons to clan broadcasts

### DIFF
--- a/src/main/java/com/flux/FluxPlugin.java
+++ b/src/main/java/com/flux/FluxPlugin.java
@@ -7,6 +7,7 @@ import com.flux.services.CompetitionScheduler;
 import com.flux.services.GoogleSheetParser;
 import com.flux.services.LoginMessageSender;
 import com.flux.services.EventPasswordManager;
+import com.flux.services.ClanRankPrefixer;
 import com.flux.services.wom.CompetitionConfigUpdater;
 import com.flux.services.wom.CompetitionDataParser;
 import com.flux.services.wom.CompetitionFinder;
@@ -29,6 +30,7 @@ import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
+import net.runelite.client.game.ChatIconManager;
 import net.runelite.client.game.SpriteManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
@@ -37,6 +39,7 @@ import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.util.ImageUtil;
 import okhttp3.OkHttpClient;
+
 import java.awt.image.BufferedImage;
 import java.util.Map;
 
@@ -60,6 +63,7 @@ public class FluxPlugin extends Plugin {
 	@Inject private SpriteManager spriteManager;
 	@Inject private ChatCommandHandler chatCommandHandler;
     @Inject private ClientThread clientThread;
+	@Inject private ChatIconManager chatIconManager;
 
 	@Getter
     private FluxPanel panel;
@@ -69,6 +73,7 @@ public class FluxPlugin extends Plugin {
     private ClanRankMonitor clanRankMonitor;
     private LoginMessageSender loginMessageSender;
     private EventPasswordManager passwordManager;
+	private ClanRankPrefixer clanRankPrefixer;
 
     @Override
     protected void startUp() {
@@ -129,6 +134,7 @@ public class FluxPlugin extends Plugin {
 
         clanRankMonitor = new ClanRankMonitor(client, this::handleRankChange);
         loginMessageSender = new LoginMessageSender(chatMessageManager, configManager, config.loginColor());
+		clanRankPrefixer = new ClanRankPrefixer(client, chatMessageManager, clientThread, chatIconManager);
 	}
 
     private void refreshAllCards() {
@@ -539,6 +545,7 @@ public class FluxPlugin extends Plugin {
     }
 
     // updates the broadcast message font color from yellow to black for easier reading
+	// now also adds clan rank icon prefix to clan messages
     @Subscribe
     public void onChatMessage(ChatMessage event) {
         String loginMessage = loginMessageSender.getLoginMessage();
@@ -550,7 +557,13 @@ public class FluxPlugin extends Plugin {
                 node.setRuneLiteFormatMessage("[Flux] " + loginMessage);
             });
         }
+
+		clanRankPrefixer.onChatMessage(event);
     }
+
+//	public ClanRankPrefixer getClanRankPrefixer() {
+//		return clanRankPrefixer;
+//	}
 
     @Provides
     FluxConfig provideConfig(ConfigManager configManager) {

--- a/src/main/java/com/flux/FluxPlugin.java
+++ b/src/main/java/com/flux/FluxPlugin.java
@@ -561,10 +561,6 @@ public class FluxPlugin extends Plugin {
 		clanRankPrefixer.onChatMessage(event);
     }
 
-//	public ClanRankPrefixer getClanRankPrefixer() {
-//		return clanRankPrefixer;
-//	}
-
     @Provides
     FluxConfig provideConfig(ConfigManager configManager) {
         return configManager.getConfig(FluxConfig.class);

--- a/src/main/java/com/flux/FluxPlugin.java
+++ b/src/main/java/com/flux/FluxPlugin.java
@@ -25,6 +25,7 @@ import net.runelite.api.GameState;
 import net.runelite.api.MessageNode;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.GameStateChanged;
+import net.runelite.api.events.GameTick;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.config.ConfigManager;
@@ -559,6 +560,11 @@ public class FluxPlugin extends Plugin {
         }
 
 		clanRankPrefixer.onChatMessage(event);
+    }
+
+    @Subscribe
+    public void onGameTick(GameTick event) {
+        clanRankPrefixer.onGameTick(event);
     }
 
     @Provides

--- a/src/main/java/com/flux/services/ClanRankPrefixer.java
+++ b/src/main/java/com/flux/services/ClanRankPrefixer.java
@@ -58,11 +58,11 @@ public class ClanRankPrefixer {
             return;
         }
 
-        // CA broadcasts only. same string used for detect + strip and it is keeping in sync.
+        // CA broadcasts only. same string used for detect and strip and it is keeping in sync.
         String withoutTags = Text.removeTags(rawMessage).trim();
         boolean isCombatAchievement = withoutTags.matches("^" + CA_ID_REGEX + ".*");
 
-        // names can have _ - nbsp instead of space, toJagexName fixes all three
+        // names can have "_" "-" nbsp instead of space, toJagexName fixes all three
         String strippedMessage = Text.toJagexName(withoutTags.replaceFirst("^" + CA_ID_REGEX, "")).trim();
 
         if (strippedMessage.startsWith("To talk in your clan's channel")) {
@@ -95,7 +95,7 @@ public class ClanRankPrefixer {
     }
 
     private void replaceCombatAchievementBroadcast(MessageNode originalNode, String rawMessage, ClanTitle title, int iconIndex) {
-        // strip only CA_ID tag, keep everything else (e.g. ironman icon)
+        // strip only CA_ID tag, keep everything else (ironman icon, GIM icon)
         String cleanText = rawMessage.replaceFirst(CA_ID_REGEX, "").trim();
         String injectedMessage = buildPrefixedMessage(cleanText, title, iconIndex);
 
@@ -156,7 +156,7 @@ public class ClanRankPrefixer {
                 continue;
             }
 
-            // re-check after apply. not CA lines don't get reclobbered, but cheap safety net.
+            // recheck after apply. not CA lines don't get reclobbered, but cheap safety net.
             if (!edit.message.equals(edit.messageNode.getRuneLiteFormatMessage())) {
                 applyEdit(edit);
             }

--- a/src/main/java/com/flux/services/ClanRankPrefixer.java
+++ b/src/main/java/com/flux/services/ClanRankPrefixer.java
@@ -1,5 +1,6 @@
 package com.flux.services;
 
+import net.runelite.api.ChatLineBuffer;
 import net.runelite.api.Client;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.MessageNode;
@@ -8,88 +9,184 @@ import net.runelite.api.clan.ClanChannelMember;
 import net.runelite.api.clan.ClanSettings;
 import net.runelite.api.clan.ClanTitle;
 import net.runelite.api.events.ChatMessage;
+import net.runelite.api.events.GameTick;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.chat.ChatMessageManager;
 import net.runelite.client.game.ChatIconManager;
 import net.runelite.client.util.Text;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.ArrayDeque;
+import java.util.Queue;
+
 @Slf4j
 public class ClanRankPrefixer {
 
-	private final Client client;
-	private final ChatMessageManager chatMessageManager;
-	private final ClientThread clientThread;
-	private final ChatIconManager chatIconManager;
+    private static final int INITIAL_APPLY_DELAY_TICKS = 1;
+    private static final int VERIFY_TICKS_AFTER_APPLY = 3;
+    private static final String CA_ID_REGEX = "CA_ID:\\d+\\|";
 
-	public ClanRankPrefixer(Client client, ChatMessageManager chatMessageManager, ClientThread clientThread, ChatIconManager chatIconManager) {
-		this.client = client;
-		this.chatMessageManager = chatMessageManager;
-		this.clientThread = clientThread;
-		this.chatIconManager = chatIconManager;
-	}
+    private final Client client;
+    private final ChatMessageManager chatMessageManager;
+    private final ClientThread clientThread;
+    private final ChatIconManager chatIconManager;
+    private final Queue<PendingEdit> pendingEdits = new ArrayDeque<>();
+    private String lastInjectedMessage = null;
 
-	public void onChatMessage(ChatMessage event) {
-		if (event.getType() != ChatMessageType.CLAN_MESSAGE) {
-			return;
-		}
+    public ClanRankPrefixer(Client client, ChatMessageManager chatMessageManager, ClientThread clientThread, ChatIconManager chatIconManager) {
+        this.client = client;
+        this.chatMessageManager = chatMessageManager;
+        this.clientThread = clientThread;
+        this.chatIconManager = chatIconManager;
+    }
 
-		ClanChannel clanChannel = client.getClanChannel();
-		ClanSettings clanSettings = client.getClanSettings();
-		if (clanChannel == null || clanSettings == null) {
-			return;
-		}
+    public void onChatMessage(ChatMessage event) {
+        if (event.getType() != ChatMessageType.CLAN_MESSAGE) {
+            return;
+        }
 
-		// check the clan member name in the message
-		String rawMessage = event.getMessage();
-		String withoutTags = Text.removeTags(rawMessage);
+        String rawMessage = event.getMessage();
 
-		// strip out CA_ID
-		withoutTags = withoutTags.replaceFirst("^CA_ID:\\d+\\|", "");
-		String strippedMessage = Text.toJagexName(withoutTags).trim();
+        if (rawMessage.equals(lastInjectedMessage)) {
+            lastInjectedMessage = null;
+            return;
+        }
 
-		if (strippedMessage.startsWith("To talk in your clan's channel")) {
-			return;
-		}
+        ClanChannel clanChannel = client.getClanChannel();
+        ClanSettings clanSettings = client.getClanSettings();
+        if (clanChannel == null || clanSettings == null) {
+            return;
+        }
 
-		ClanChannelMember matched = null;
-		String matchedName = null;
+        // CA broadcasts only. same string used for detect + strip and it is keeping in sync.
+        String withoutTags = Text.removeTags(rawMessage).trim();
+        boolean isCombatAchievement = withoutTags.matches("^" + CA_ID_REGEX + ".*");
 
-		for (ClanChannelMember member : clanChannel.getMembers()) {
-			String name = Text.toJagexName(member.getName());
-			if (strippedMessage.startsWith(name) && (matchedName == null || name.length() > matchedName.length())) {
-				matched = member;
-				matchedName = name;
-			}
-		}
+        // names can have _ - nbsp instead of space, toJagexName fixes all three
+        String strippedMessage = Text.toJagexName(withoutTags.replaceFirst("^" + CA_ID_REGEX, "")).trim();
 
-		if (matched == null) {
-			log.debug("No clan member match for broadcast: '{}'", strippedMessage);
-			log.debug("Clan members: {}", clanChannel.getMembers().stream()
-					.map(m -> "'" + Text.toJagexName(m.getName()) + "'")
-					.collect(java.util.stream.Collectors.joining(", ")));
-			return;
-		}
+        if (strippedMessage.startsWith("To talk in your clan's channel")) {
+            return;
+        }
 
-		ClanTitle title = clanSettings.titleForRank(matched.getRank());
-		if (title == null) {
-			log.debug("No title found for rank {} (member {})", matched.getRank(), matchedName);
-			return;
-		}
+        ClanChannelMember matched = findMatchingMember(clanChannel, strippedMessage);
+        if (matched == null) {
+            log.debug("No clan member match for broadcast: '{}'", strippedMessage);
+            return;
+        }
 
-		int iconIndex = chatIconManager.getIconNumber(title);
-		String newMessage = iconIndex >= 0
-				? "<img=" + iconIndex + "> " + rawMessage
-				: "[" + title.getName() + "] " + rawMessage;
+        ClanTitle title = clanSettings.titleForRank(matched.getRank());
+        if (title == null) {
+            log.debug("No title found for rank {} (member {})", matched.getRank(), Text.toJagexName(matched.getName()));
+            return;
+        }
 
-		log.debug("Matched '{}' to rank '{}', icon index {}, new message: '{}'",
-				matchedName, title.getName(), iconIndex, newMessage);
+        int iconIndex = chatIconManager.getIconNumber(title);
 
-		MessageNode messageNode = event.getMessageNode();
-		clientThread.invokeLater(() -> {
-			messageNode.setRuneLiteFormatMessage(newMessage);
-			chatMessageManager.update(messageNode);
-			client.refreshChat();
-		});
-	}
+        if (isCombatAchievement) {
+            // client renders CA lines its own way, editing text does nothing here.
+            // only fix I am thinking of is delete node, publish fresh one
+            replaceCombatAchievementBroadcast(event.getMessageNode(), rawMessage, title, iconIndex);
+            return;
+        }
+
+        String newMessage = buildPrefixedMessage(rawMessage, title, iconIndex);
+        pendingEdits.add(new PendingEdit(event.getMessageNode(), newMessage, INITIAL_APPLY_DELAY_TICKS));
+    }
+
+    private void replaceCombatAchievementBroadcast(MessageNode originalNode, String rawMessage, ClanTitle title, int iconIndex) {
+        // strip only CA_ID tag, keep everything else (e.g. ironman icon)
+        String cleanText = rawMessage.replaceFirst(CA_ID_REGEX, "").trim();
+        String injectedMessage = buildPrefixedMessage(cleanText, title, iconIndex);
+
+        lastInjectedMessage = injectedMessage;
+        clientThread.invokeLater(() -> {
+            // remove old line, then add new one. order matters, do not swap.
+            ChatLineBuffer buffer = client.getChatLineMap().get(ChatMessageType.CLAN_MESSAGE.getType());
+            if (buffer != null) {
+                buffer.removeMessageNode(originalNode);
+            }
+            client.addChatMessage(ChatMessageType.CLAN_MESSAGE, "", injectedMessage, null);
+            client.refreshChat();
+        });
+    }
+
+    private String buildPrefixedMessage(String message, ClanTitle title, int iconIndex) {
+        // -1 means no icon registered for rank, fall back to plain text bracket
+        return iconIndex >= 0
+                ? "<img=" + iconIndex + "> " + message
+                : "[" + title.getName() + "] " + message;
+    }
+
+    private ClanChannelMember findMatchingMember(ClanChannel clanChannel, String strippedMessage) {
+        // longest match wins. stops short names matching inside longer ones.
+        ClanChannelMember matched = null;
+        String matchedName = null;
+
+        for (ClanChannelMember member : clanChannel.getMembers()) {
+            String name = Text.toJagexName(member.getName());
+            if (strippedMessage.startsWith(name) && (matchedName == null || name.length() > matchedName.length())) {
+                matched = member;
+                matchedName = name;
+            }
+        }
+
+        return matched;
+    }
+
+    public void onGameTick(GameTick event) {
+        if (pendingEdits.isEmpty()) {
+            return;
+        }
+
+        int size = pendingEdits.size();
+        for (int i = 0; i < size; i++) {
+            PendingEdit edit = pendingEdits.poll();
+
+            if (!edit.applied) {
+                edit.ticksRemaining--;
+                if (edit.ticksRemaining <= 0) {
+                    applyEdit(edit);
+                    edit.applied = true;
+                    edit.ticksRemaining = VERIFY_TICKS_AFTER_APPLY;
+                    pendingEdits.add(edit);
+                } else {
+                    pendingEdits.add(edit);
+                }
+                continue;
+            }
+
+            // re-check after apply. not CA lines don't get reclobbered, but cheap safety net.
+            if (!edit.message.equals(edit.messageNode.getRuneLiteFormatMessage())) {
+                applyEdit(edit);
+            }
+
+            edit.ticksRemaining--;
+            if (edit.ticksRemaining > 0) {
+                pendingEdits.add(edit);
+            }
+        }
+    }
+
+    private void applyEdit(PendingEdit edit) {
+        clientThread.invokeLater(() -> {
+            edit.messageNode.setRuneLiteFormatMessage(edit.message);
+            chatMessageManager.update(edit.messageNode);
+            client.refreshChat();
+        });
+    }
+
+    // one edit waiting for tick delay, then a few more ticks to verify it stuck
+    private static class PendingEdit {
+        final MessageNode messageNode;
+        final String message;
+        int ticksRemaining;
+        boolean applied = false;
+
+        PendingEdit(MessageNode messageNode, String message, int ticksRemaining) {
+            this.messageNode = messageNode;
+            this.message = message;
+            this.ticksRemaining = ticksRemaining;
+        }
+    }
 }

--- a/src/main/java/com/flux/services/ClanRankPrefixer.java
+++ b/src/main/java/com/flux/services/ClanRankPrefixer.java
@@ -40,9 +40,14 @@ public class ClanRankPrefixer {
 			return;
 		}
 
-		// normaliez and find the username
+		// check the clan member name in the message
 		String rawMessage = event.getMessage();
-		String strippedMessage = Text.removeTags(rawMessage).replace('\u00A0', ' ').trim();
+		String strippedMessage = Text.toJagexName(Text.removeTags(rawMessage)).trim();
+
+		if (strippedMessage.startsWith("To talk in your clan's channel")) {
+			return;
+		}
+
 		strippedMessage = strippedMessage.replaceFirst("^CA_ID:\\d+\\|", "");
 
 		ClanChannelMember matched = null;
@@ -74,6 +79,9 @@ public class ClanRankPrefixer {
 		String newMessage = iconIndex >= 0
 				? "<img=" + iconIndex + "> " + rawMessage
 				: "[" + title.getName() + "] " + rawMessage;
+
+		log.debug("Matched '{}' to rank '{}', icon index {}, new message: '{}'",
+				matchedName, title.getName(), iconIndex, newMessage);
 
 		MessageNode messageNode = event.getMessageNode();
 		clientThread.invokeLater(() -> {

--- a/src/main/java/com/flux/services/ClanRankPrefixer.java
+++ b/src/main/java/com/flux/services/ClanRankPrefixer.java
@@ -42,13 +42,15 @@ public class ClanRankPrefixer {
 
 		// check the clan member name in the message
 		String rawMessage = event.getMessage();
-		String strippedMessage = Text.toJagexName(Text.removeTags(rawMessage)).trim();
+		String withoutTags = Text.removeTags(rawMessage);
+
+		// strip out CA_ID
+		withoutTags = withoutTags.replaceFirst("^CA_ID:\\d+\\|", "");
+		String strippedMessage = Text.toJagexName(withoutTags).trim();
 
 		if (strippedMessage.startsWith("To talk in your clan's channel")) {
 			return;
 		}
-
-		strippedMessage = strippedMessage.replaceFirst("^CA_ID:\\d+\\|", "");
 
 		ClanChannelMember matched = null;
 		String matchedName = null;

--- a/src/main/java/com/flux/services/ClanRankPrefixer.java
+++ b/src/main/java/com/flux/services/ClanRankPrefixer.java
@@ -1,0 +1,85 @@
+package com.flux.services;
+
+import net.runelite.api.Client;
+import net.runelite.api.ChatMessageType;
+import net.runelite.api.MessageNode;
+import net.runelite.api.clan.ClanChannel;
+import net.runelite.api.clan.ClanChannelMember;
+import net.runelite.api.clan.ClanSettings;
+import net.runelite.api.clan.ClanTitle;
+import net.runelite.api.events.ChatMessage;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.chat.ChatMessageManager;
+import net.runelite.client.game.ChatIconManager;
+import net.runelite.client.util.Text;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ClanRankPrefixer {
+
+	private final Client client;
+	private final ChatMessageManager chatMessageManager;
+	private final ClientThread clientThread;
+	private final ChatIconManager chatIconManager;
+
+	public ClanRankPrefixer(Client client, ChatMessageManager chatMessageManager, ClientThread clientThread, ChatIconManager chatIconManager) {
+		this.client = client;
+		this.chatMessageManager = chatMessageManager;
+		this.clientThread = clientThread;
+		this.chatIconManager = chatIconManager;
+	}
+
+	public void onChatMessage(ChatMessage event) {
+		if (event.getType() != ChatMessageType.CLAN_MESSAGE) {
+			return;
+		}
+
+		ClanChannel clanChannel = client.getClanChannel();
+		ClanSettings clanSettings = client.getClanSettings();
+		if (clanChannel == null || clanSettings == null) {
+			return;
+		}
+
+		// normaliez and find the username
+		String rawMessage = event.getMessage();
+		String strippedMessage = Text.removeTags(rawMessage).replace('\u00A0', ' ').trim();
+		strippedMessage = strippedMessage.replaceFirst("^CA_ID:\\d+\\|", "");
+
+		ClanChannelMember matched = null;
+		String matchedName = null;
+
+		for (ClanChannelMember member : clanChannel.getMembers()) {
+			String name = Text.toJagexName(member.getName());
+			if (strippedMessage.startsWith(name) && (matchedName == null || name.length() > matchedName.length())) {
+				matched = member;
+				matchedName = name;
+			}
+		}
+
+		if (matched == null) {
+			log.debug("No clan member match for broadcast: '{}'", strippedMessage);
+			log.debug("Clan members: {}", clanChannel.getMembers().stream()
+					.map(m -> "'" + Text.toJagexName(m.getName()) + "'")
+					.collect(java.util.stream.Collectors.joining(", ")));
+			return;
+		}
+
+		ClanTitle title = clanSettings.titleForRank(matched.getRank());
+		if (title == null) {
+			log.debug("No title found for rank {} (member {})", matched.getRank(), matchedName);
+			return;
+		}
+
+		int iconIndex = chatIconManager.getIconNumber(title);
+		String newMessage = iconIndex >= 0
+				? "<img=" + iconIndex + "> " + rawMessage
+				: "[" + title.getName() + "] " + rawMessage;
+
+		MessageNode messageNode = event.getMessageNode();
+		clientThread.invokeLater(() -> {
+			messageNode.setRuneLiteFormatMessage(newMessage);
+			chatMessageManager.update(messageNode);
+			client.refreshChat();
+		});
+	}
+}

--- a/src/main/java/com/flux/services/LoginMessageSender.java
+++ b/src/main/java/com/flux/services/LoginMessageSender.java
@@ -46,14 +46,6 @@ public class LoginMessageSender {
         hasSentMessage = true;
     }
 
-    public void reset() {
-        hasSentMessage = false;
-    }
-
-    public boolean hasSentMessage() {
-        return hasSentMessage;
-    }
-
     public String getLoginMessage() {
         return configManager.getConfiguration(CONFIG_GROUP, CONFIG_KEY);
     }


### PR DESCRIPTION
- added ClanRankPrefixer class to handle clan rank icon prepending to clan broadcasts like new speed PBs, CA, clogs, etc.
- cleaned up unused methods in LoginMessageSender
- updated FluxPlugin class 